### PR TITLE
修复WM复制消息异位的问题

### DIFF
--- a/src/Wfa.App/Controls/Market/ItemOrder.xaml
+++ b/src/Wfa.App/Controls/Market/ItemOrder.xaml
@@ -104,7 +104,7 @@
                     Margin="0,0,0,-4"
                     Padding="8,4"
                     VerticalAlignment="Bottom"
-                    Command="{x:Bind ViewModel.CopyMessageCommand}">
+                    Command="{x:Bind ViewModel.CopyMessageCommand, Mode=OneWay}">
                     <StackPanel Orientation="Horizontal" Spacing="4">
                         <icons:RegularFluentIcon
                             VerticalAlignment="Center"

--- a/src/Wfa.App/Controls/Market/LibraryMarketButton.xaml
+++ b/src/Wfa.App/Controls/Market/LibraryMarketButton.xaml
@@ -27,7 +27,7 @@
         </StackPanel>
         <Button.Flyout>
             <Flyout FlyoutPresenterStyle="{StaticResource ThinPaddingFlyoutPresenterStyle}" Placement="Bottom">
-                <muxc:ItemsRepeater ItemsSource="{x:Bind ViewModel.MarketItems}">
+                <muxc:ItemsRepeater ItemsSource="{x:Bind ViewModel.MarketItems, Mode=OneWay}">
                     <muxc:ItemsRepeater.Layout>
                         <muxc:StackLayout Spacing="2" />
                     </muxc:ItemsRepeater.Layout>

--- a/src/Wfa.App/Controls/Market/LichOrder.xaml
+++ b/src/Wfa.App/Controls/Market/LichOrder.xaml
@@ -12,7 +12,7 @@
     d:DesignWidth="400"
     mc:Ignorable="d">
 
-    <app:CardPanel Command="{x:Bind ViewModel.OpenOrderCommand}" IsEnableHoverAnimation="False">
+    <app:CardPanel Command="{x:Bind ViewModel.OpenOrderCommand, Mode=OneWay}" IsEnableHoverAnimation="False">
         <Grid Padding="16">
             <Grid.RowDefinitions>
                 <RowDefinition Height="Auto" />

--- a/src/Wfa.App/Controls/Market/RivenOrder.xaml
+++ b/src/Wfa.App/Controls/Market/RivenOrder.xaml
@@ -5,7 +5,6 @@
     xmlns:app="using:Wfa.App.Controls.App"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:ext="using:Wfa.App.Resources.Extensions"
-    xmlns:icons="using:Richasy.FluentIcon.Uwp"
     xmlns:local="using:Wfa.App.Controls.Market"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
@@ -13,7 +12,7 @@
     d:DesignWidth="400"
     mc:Ignorable="d">
 
-    <app:CardPanel Command="{x:Bind ViewModel.OpenOrderCommand}" IsEnableHoverAnimation="False">
+    <app:CardPanel Command="{x:Bind ViewModel.OpenOrderCommand, Mode=OneWay}" IsEnableHoverAnimation="False">
         <Grid Padding="16" RowSpacing="4">
             <Grid.RowDefinitions>
                 <RowDefinition Height="Auto" />


### PR DESCRIPTION
<!-- 🚨 请不要跳过或删除下面的信息，它们都是评估与测试所需的信息，完整填写有助于更快通过评审 🚨 -->

<!-- 👉 一个 PR 最好只解决一个 Issue，除非这些问题彼此关联 -->

<!-- 📝 请始终打开 PR 中的 `☑️ Allow edits by maintainers` 按钮， WFA 使用了较为严格的项目模板，维护者可以帮助你修改一些细微的错误或者格式问题 🎉 -->

## Close #34 

修复在复制订单消息时，消息与卡片对不上的问题

## PR 类型

这个 PR 的目的是什么？

<!-- 请取消对应类型的注释 -->

- Bug 修复
<!-- - 功能 -->
<!-- - 代码样式更新 -->
<!-- - 重构 （没有功能修改，没有 API 更新） -->
<!-- - Build 或 CI 更新 -->
<!-- - 文档内容更新 -->
<!-- - 其他，请描述内容： -->

## 当前行为是什么？

在订单页重复刷新几次后，消息和卡片对不上

## 新的行为是什么？

使用 OneWay 绑定强化命令关系，避免因为虚拟化容器复用的原因导致命令触发错误

## PR 检查清单

请检查你的 PR 是否满足以下要求：<!-- 删除掉那些不适用于当前 PR 的内容 -->

- [x] 应用成功启动
- [x] 文件头已经被添加至所有源文件中
- [x] **不**包含破坏式更新

<!-- 如果这个 PR 包含破坏式更新，请在下面描述对现有应用的影响以及如何适应新变化 -->

## 备注

<!-- 请添加任何你认为有帮助的信息 -->
